### PR TITLE
Fix Gemfile which used to specify an unreleased version of devtools.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,8 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'devtools', git: 'https://github.com/rom-rb/devtools.git'
-gem 'fuubar',   git: 'https://github.com/lgierth/fuubar.git',
-                ref: 'static-percentage'
+gem 'devtools', '~> 0.1.4'
+gem 'fuubar',   '~> 2.0.0'
 gem 'awesome_print'
 
 gem 'rspec-its'

--- a/Gemfile.devtools
+++ b/Gemfile.devtools
@@ -1,9 +1,8 @@
 # encoding: utf-8
 
 group :development do
-  gem 'rake',       '~> 10.3.2'
-  gem 'rspec',      '~> 2.99.0'
-  gem 'rspec-core', '~> 2.99.0'
+  gem 'rake',       '~> 10.4.2'
+  gem 'rspec',      '~> 3.4.0'
   gem 'yard',       '~> 0.8.7.4'
 
   platform :rbx do
@@ -35,16 +34,16 @@ end
 
 group :metrics do
   gem 'coveralls', '~> 0.7.0'
-  gem 'flay',      '~> 2.5.0'
-  gem 'flog',      '~> 4.2.1'
-  gem 'reek',      '~> 1.3.7'
-  gem 'rubocop',   '~> 0.23.0'
-  gem 'simplecov', '~> 0.7.1'
+  gem 'flay',      '~> 2.6.1'
+  gem 'flog',      '~> 4.3.2'
+  gem 'reek',      '~> 3.7.0'
+  gem 'rubocop',   '~> 0.35.1'
+  gem 'simplecov', '~> 0.10.0'
   gem 'yardstick', '~> 0.9.9'
 
   platforms :mri do
-    gem 'mutant',       '~> 0.5.23'
-    gem 'mutant-rspec', '~> 0.5.21'
+    gem 'mutant',       '~> 0.8.10'
+    gem 'mutant-rspec', '~> 0.8.8'
   end
 
   platforms :ruby_19, :ruby_20 do

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -66,11 +66,11 @@ SignalException:
   EnforcedStyle: only_raise
 
 # Do not prefer do/end over {} for multiline blocks
-Blocks:
+BlockDelimiters:
   Enabled: false
 
 # Allow empty lines around body
-EmptyLinesAroundBody:
+EmptyLinesAroundBlockBody:
   Enabled: false
 
 # Prefer String#% over Kernel#sprintf

--- a/lib/promise/callback.rb
+++ b/lib/promise/callback.rb
@@ -4,7 +4,8 @@ class Promise
   class Callback
     def initialize(promise, on_fulfill, on_reject, next_promise)
       @promise = promise
-      @on_fulfill, @on_reject = on_fulfill, on_reject
+      @on_fulfill = on_fulfill
+      @on_reject = on_reject
       @next_promise = next_promise
     end
 


### PR DESCRIPTION
Fixes #6

I upgraded devtools to the latest released version, and upgraded other gems to resolve conflicts.  I also addressed rubocop warnings from renamed checks and changed the code due to one warning about a parallel assignment.