### PR TITLE
feat: Add Promise.resolve utility method.

### DIFF
--- a/lib/promise.rb
+++ b/lib/promise.rb
@@ -12,6 +12,11 @@ class Promise
 
   attr_reader :state, :value, :reason, :backtrace
 
+  def self.resolve(obj)
+    return obj if obj.instance_of?(self)
+    new.tap { |promise| promise.fulfill(obj) }
+  end
+
   def initialize
     @state = :pending
     @callbacks = []

--- a/spec/unit/promise_spec.rb
+++ b/spec/unit/promise_spec.rb
@@ -408,5 +408,22 @@ describe Promise do
         expect(subject.sync).to be(value)
       end
     end
+
+    describe '.resolve' do
+      it 'returns a fulfilled promise from a non-promise' do
+        promise = Promise.resolve(123)
+        expect(promise.fulfilled?).to eq(true)
+        expect(promise.value).to eq(123)
+      end
+
+      it 'assumes the state of a given promise' do
+        promise = Promise.new
+        new_promise = Promise.resolve(promise)
+        expect(new_promise.pending?).to eq(true)
+        promise.fulfill(42)
+        expect(new_promise.fulfilled?).to eq(true)
+        expect(new_promise.value).to eq(42)
+      end
+    end
   end
 end


### PR DESCRIPTION
This implements the [`Promise.resolve` javascript method](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve) which I think is useful for handling the return value of a function that is allowed to return a promise or a value.