### PR TITLE
feat: Add Promise.all utility method.

### DIFF
--- a/config/reek.yml
+++ b/config/reek.yml
@@ -64,6 +64,7 @@ TooManyMethods:
 TooManyStatements:
   enabled: true
   exclude:
+  - initialize
   - each
   max_statements: 5
 UncommunicativeMethodName:

--- a/lib/promise.rb
+++ b/lib/promise.rb
@@ -4,6 +4,7 @@ require 'promise/version'
 
 require 'promise/callback'
 require 'promise/progress'
+require 'promise/group'
 
 class Promise
   Error = Class.new(RuntimeError)
@@ -15,6 +16,10 @@ class Promise
   def self.resolve(obj)
     return obj if obj.instance_of?(self)
     new.tap { |promise| promise.fulfill(obj) }
+  end
+
+  def self.all(enumerable)
+    Group.new(enumerable).promise
   end
 
   def initialize

--- a/lib/promise/group.rb
+++ b/lib/promise/group.rb
@@ -1,0 +1,51 @@
+class Promise
+  class Group
+    attr_reader :promise
+
+    def initialize(inputs)
+      @promise = Promise.new
+      @inputs = inputs
+      @remaining = count_promises
+      if @remaining.zero?
+        promise.fulfill(inputs)
+      else
+        chain_inputs
+      end
+    end
+
+    private
+
+    def chain_inputs
+      on_fulfill = method(:on_fulfill)
+      on_reject = promise.method(:reject)
+      each_promise do |input_promise|
+        input_promise.then(on_fulfill, on_reject)
+      end
+    end
+
+    def on_fulfill(_result)
+      @remaining -= 1
+      if @remaining.zero?
+        result = @inputs.map { |obj| promise?(obj) ? obj.value : obj }
+        promise.fulfill(result)
+      end
+    end
+
+    def promise?(obj)
+      obj.instance_of?(Promise)
+    end
+
+    def count_promises
+      count = 0
+      each_promise { count += 1 }
+      count
+    end
+
+    def each_promise
+      @inputs.each do |obj|
+        yield obj if promise?(obj)
+      end
+    end
+  end
+  private_constant :Group
+end

--- a/spec/unit/promise_spec.rb
+++ b/spec/unit/promise_spec.rb
@@ -425,5 +425,54 @@ describe Promise do
         expect(new_promise.value).to eq(42)
       end
     end
+
+    describe '.all' do
+      it 'returns a fulfilled promise for an array with no promises' do
+        obj = Object.new
+        promise = Promise.all([1, 'b', obj])
+        expect(promise.fulfilled?).to eq(true)
+        expect(promise.value).to eq([1, 'b', obj])
+      end
+
+      it 'fulfills the result when all args are fulfilled' do
+        p1 = Promise.new
+        p2 = Promise.new
+
+        result = Promise.all([p1, p2, 3])
+
+        expect(result).to be_pending
+        p2.fulfill('b')
+        expect(result).to be_pending
+        p1.fulfill(:a)
+        expect(result).to be_fulfilled
+        expect(result.value).to eq([:a, 'b', 3])
+      end
+
+      it 'leaves result pending if only the first input arg is fulfilled' do
+        p1 = Promise.new
+        p1.fulfill('a')
+        p2 = Promise.new
+
+        result = Promise.all([p1, p2])
+
+        expect(result).to be_pending
+        p2.fulfill(:b)
+        expect(result).to be_fulfilled
+        expect(result.value).to eq(['a', :b])
+      end
+
+      it 'rejects the result when any args is rejected' do
+        p1 = Promise.new
+        p2 = Promise.new
+        reason = RuntimeError.new('p1 failed')
+
+        result = Promise.all([p1, p2])
+
+        expect(result).to be_pending
+        p1.reject(reason)
+        expect(result).to be_rejected
+        expect(result.reason).to eq(reason)
+      end
+    end
   end
 end


### PR DESCRIPTION
@eapache for review

This PR adds an implementation of the [Promise.all javascript method](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all) which can be useful to wait for the result of multiple promises.