### PR TITLE
fix: Return instances of the custom promise class from its methods.

### DIFF
--- a/lib/promise.rb
+++ b/lib/promise.rb
@@ -19,7 +19,7 @@ class Promise
   end
 
   def self.all(enumerable)
-    Group.new(enumerable).promise
+    Group.new(new, enumerable).promise
   end
 
   def initialize
@@ -41,7 +41,7 @@ class Promise
 
   def then(on_fulfill = nil, on_reject = nil, &block)
     on_fulfill ||= block
-    next_promise = Promise.new
+    next_promise = self.class.new
 
     add_callback { Callback.new(self, on_fulfill, on_reject, next_promise) }
     next_promise

--- a/lib/promise/group.rb
+++ b/lib/promise/group.rb
@@ -2,8 +2,8 @@ class Promise
   class Group
     attr_reader :promise
 
-    def initialize(inputs)
-      @promise = Promise.new
+    def initialize(result_promise, inputs)
+      @promise = result_promise
       @inputs = inputs
       @remaining = count_promises
       if @remaining.zero?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@ if ENV['COVERAGE'] == 'true'
 end
 
 require 'promise'
+require_relative 'support/delayed_promise'
 
 require 'awesome_print'
 require 'devtools/spec_helper' if Gem.ruby_version >= Gem::Version.new('2.1')

--- a/spec/support/delayed_promise.rb
+++ b/spec/support/delayed_promise.rb
@@ -1,0 +1,22 @@
+class DelayedPromise < Promise
+  BrokenPromise = Class.new(StandardError)
+
+  class << self
+    def deferred
+      @deferred ||= []
+    end
+
+    def call_deferred
+      deferred.shift.call until deferred.empty?
+    end
+  end
+
+  def wait
+    DelayedPromise.call_deferred
+    raise BrokenPromise if pending?
+  end
+
+  def defer(&block)
+    DelayedPromise.deferred << block
+  end
+end

--- a/spec/unit/promise_spec.rb
+++ b/spec/unit/promise_spec.rb
@@ -170,7 +170,16 @@ describe Promise do
 
   describe '3.2.4' do
     it 'returns before on_fulfill or on_reject is called' do
-      skip 'To be implemented by application code'
+      called = false
+      p1 = DelayedPromise.new
+      p2 = p1.then { called = true }
+
+      p1.fulfill(42)
+
+      expect(called).to eq(false)
+      DelayedPromise.call_deferred
+      expect(called).to eq(true)
+      expect(p2).to be_fulfilled
     end
   end
 
@@ -472,6 +481,16 @@ describe Promise do
         p1.reject(reason)
         expect(result).to be_rejected
         expect(result.reason).to eq(reason)
+      end
+
+      it 'returns an instance of the class it is called on' do
+        p1 = Promise.new
+
+        result = DelayedPromise.all([p1, 2])
+
+        expect(result).to be_an_instance_of(DelayedPromise)
+        p1.fulfill(1.0)
+        expect(result.sync).to eq([1.0, 2])
       end
     end
   end


### PR DESCRIPTION
@eapache for review

## Problem

When using the Promise.rb in graphql-batch, I initially tried to put the wait logic in a custom promise class so that I could call `.sync` on the promise.  However, this meant that it couldn't be used from a promise returned from `.then`, since Promise.rb was using `Promise.new` to return the result.

Similarly, the [README](https://github.com/lgierth/promise.rb/blob/v0.6.1/README.md#usage) recommends implementing `defer` on a custom Promise class for spec compliance.  However, that compliance wouldn't apply to calls to `.then` on a promise returned from `.then`.

## Solution

Use `self.class.new` in Promise#then, and `new` from `Promise.all`.