### PR TITLE
Make add_callback, dispatch, dispatch! and Promise::Callback private.

### DIFF
--- a/lib/promise.rb
+++ b/lib/promise.rb
@@ -47,14 +47,6 @@ class Promise
     next_promise
   end
 
-  def add_callback(&generator)
-    if pending?
-      @callbacks << generator
-    else
-      dispatch!(generator.call)
-    end
-  end
-
   def sync
     wait if pending?
     raise reason if rejected?
@@ -75,6 +67,20 @@ class Promise
     end
   end
 
+  def defer
+    yield
+  end
+
+  private
+
+  def add_callback(&generator)
+    if pending?
+      @callbacks << generator
+    else
+      dispatch!(generator.call)
+    end
+  end
+
   def dispatch(backtrace)
     if pending?
       yield
@@ -86,9 +92,5 @@ class Promise
 
   def dispatch!(callback)
     defer { callback.dispatch }
-  end
-
-  def defer
-    yield
   end
 end

--- a/lib/promise/callback.rb
+++ b/lib/promise/callback.rb
@@ -47,4 +47,5 @@ class Promise
       source.then(on_fulfill, on_reject)
     end
   end
+  private_constant :Callback
 end


### PR DESCRIPTION
@lgierth any reason to keep these public?

It seems like they were meant to be private, since they look like an implementation detail.