### PR TITLE
break: Remove Promise#backtrace, use #reason.backtrace instead.

### DIFF
--- a/config/flog.yml
+++ b/config/flog.yml
@@ -1,2 +1,2 @@
 ---
-threshold: 9.7
+threshold: 10.6

--- a/lib/promise.rb
+++ b/lib/promise.rb
@@ -67,7 +67,7 @@ class Promise
   def reject(reason = nil)
     dispatch do
       @state = :rejected
-      @reason = reason || Error.new.tap { |err| err.set_backtrace(caller) }
+      @reason = reason_coercion(reason || Error)
     end
   end
 
@@ -76,6 +76,16 @@ class Promise
   end
 
   private
+
+  def reason_coercion(reason)
+    case reason
+    when Exception
+      reason.set_backtrace(caller) unless reason.backtrace
+    when Class
+      reason = reason_coercion(reason.new) if reason <= Exception
+    end
+    reason
+  end
 
   def add_callback(callback)
     if pending?

--- a/lib/promise/callback.rb
+++ b/lib/promise/callback.rb
@@ -3,8 +3,8 @@
 class Promise
   class Callback
     def self.assume_state(source, target)
-      on_fulfill = proc { |value| target.fulfill(value, source.backtrace) }
-      on_reject  = proc { |reason| target.reject(reason, source.backtrace) }
+      on_fulfill = target.method(:fulfill)
+      on_reject = target.method(:reject)
       source.then(on_fulfill, on_reject)
     end
 
@@ -25,11 +25,10 @@ class Promise
 
     def call_block(block, param)
       if block
-        backtrace = @promise.backtrace
         begin
-          @next_promise.fulfill(block.call(param), backtrace)
+          @next_promise.fulfill(block.call(param))
         rescue => ex
-          @next_promise.reject(ex, backtrace)
+          @next_promise.reject(ex)
         end
       else
         self.class.assume_state(@promise, @next_promise)

--- a/spec/unit/promise_spec.rb
+++ b/spec/unit/promise_spec.rb
@@ -8,12 +8,11 @@ describe Promise do
   let(:value) { double('value') }
   let(:other_value) { double('other_value') }
 
-  let(:backtrace) { caller }
   let(:reason) do
-    StandardError.new('reason').tap { |ex| ex.set_backtrace(backtrace) }
+    StandardError.new('reason').tap { |err| err.set_backtrace(caller) }
   end
   let(:other_reason) do
-    StandardError.new('other_reason').tap { |ex| ex.set_backtrace(backtrace) }
+    StandardError.new('other_reason').tap { |err| err.set_backtrace(caller) }
   end
 
   describe '3.1.1 pending' do
@@ -251,7 +250,6 @@ describe Promise do
 
       expect(promise2).to be_fulfilled
       expect(promise2.value).to eq(other_value)
-      expect(promise2.backtrace).to be(subject.backtrace)
     end
 
     it 'fulfills promise2 with value returned by on_reject' do
@@ -260,7 +258,6 @@ describe Promise do
 
       expect(promise2).to be_fulfilled
       expect(promise2.value).to eq(other_value)
-      expect(promise2.backtrace).to be(subject.backtrace)
     end
 
     it 'rejects promise2 with error raised by on_fulfill' do
@@ -269,7 +266,6 @@ describe Promise do
 
       expect(promise2).to be_rejected
       expect(promise2.reason).to eq(error)
-      expect(promise2.backtrace).to be(subject.backtrace)
     end
 
     it 'rejects promise2 with error raised by on_reject' do
@@ -278,7 +274,6 @@ describe Promise do
 
       expect(promise2).to be_rejected
       expect(promise2.reason).to eq(error)
-      expect(promise2.backtrace).to be(subject.backtrace)
     end
 
     describe 'on_fulfill returns promise' do
@@ -291,7 +286,6 @@ describe Promise do
         returned_promise.fulfill(other_value)
         expect(promise2).to be_fulfilled
         expect(promise2.value).to eq(other_value)
-        expect(promise2.backtrace).to be(returned_promise.backtrace)
       end
 
       it 'makes promise2 assume rejected state of returned promise' do
@@ -303,7 +297,6 @@ describe Promise do
         returned_promise.reject(other_reason)
         expect(promise2).to be_rejected
         expect(promise2.reason).to eq(other_reason)
-        expect(promise2.backtrace).to be(returned_promise.backtrace)
       end
     end
 
@@ -317,7 +310,6 @@ describe Promise do
         returned_promise.fulfill(other_value)
         expect(promise2).to be_fulfilled
         expect(promise2.value).to eq(other_value)
-        expect(promise2.backtrace).to be(returned_promise.backtrace)
       end
 
       it 'makes promise2 assume rejected state of returned promise' do
@@ -329,7 +321,6 @@ describe Promise do
         returned_promise.reject(other_reason)
         expect(promise2).to be_rejected
         expect(promise2.reason).to eq(other_reason)
-        expect(promise2.backtrace).to be(returned_promise.backtrace)
       end
     end
 
@@ -340,7 +331,6 @@ describe Promise do
 
         expect(promise2).to be_fulfilled
         expect(promise2.value).to eq(value)
-        expect(promise2.backtrace).to be(subject.backtrace)
       end
     end
 
@@ -351,7 +341,6 @@ describe Promise do
 
         expect(promise2).to be_rejected
         expect(promise2.reason).to eq(reason)
-        expect(promise2.backtrace).to be(subject.backtrace)
       end
     end
   end
@@ -399,12 +388,6 @@ describe Promise do
         expect(subject.value).to be(nil)
       end
 
-      it 'sets the backtrace' do
-        subject.fulfill
-        expect(subject.backtrace.join)
-          .to include(__FILE__ + ':' + (__LINE__ - 2).to_s)
-      end
-
       it 'assumes the state of a given promise' do
         promise = Promise.new
 
@@ -424,12 +407,12 @@ describe Promise do
 
       it 'does not require a reason' do
         subject.reject
-        expect(subject.reason).to be(Promise::Error)
+        expect(subject.reason).to be_a(Promise::Error)
       end
 
       it 'sets the backtrace' do
         subject.reject
-        expect(subject.backtrace.join)
+        expect(subject.reason.backtrace.join)
           .to include(__FILE__ + ':' + (__LINE__ - 2).to_s)
       end
     end

--- a/spec/unit/promise_spec.rb
+++ b/spec/unit/promise_spec.rb
@@ -8,8 +8,9 @@ describe Promise do
   let(:value) { double('value') }
   let(:other_value) { double('other_value') }
 
+  let(:backtrace) { caller }
   let(:reason) do
-    StandardError.new('reason').tap { |err| err.set_backtrace(caller) }
+    StandardError.new('reason').tap { |err| err.set_backtrace(backtrace) }
   end
   let(:other_reason) do
     StandardError.new('other_reason').tap { |err| err.set_backtrace(caller) }
@@ -414,6 +415,26 @@ describe Promise do
         subject.reject
         expect(subject.reason.backtrace.join)
           .to include(__FILE__ + ':' + (__LINE__ - 2).to_s)
+      end
+
+      it 'leaves backtrace if already set' do
+        subject.reject(reason)
+        expect(subject.reason.backtrace).to eq(backtrace)
+      end
+
+      it 'instantiates exception class' do
+        subject.reject(Exception)
+        expect(subject.reason).to be_a(Exception)
+      end
+
+      it 'instantiates exception subclasses' do
+        subject.reject(RuntimeError)
+        expect(subject.reason).to be_a(RuntimeError)
+      end
+
+      it "doesn't instantiate non-error classes" do
+        subject.reject(Hash)
+        expect(subject.reason).to eq(Hash)
       end
     end
 


### PR DESCRIPTION
@lgierth why do we need a backtrace when a promise is fulfilled?  Also, can't we just use the backtrace on the exception when a promise is rejected?

If `fulfill` is called without arguments, this pull request does add a backtrace to the default error, which will now be an instance rather than a class.