### PR TITLE
fix: Avoid re-raising exception that occur in then callbacks.

### DIFF
--- a/lib/promise/callback.rb
+++ b/lib/promise/callback.rb
@@ -29,7 +29,6 @@ class Promise
       block.call(param)
     rescue => ex
       @next_promise.reject(ex, @promise.backtrace)
-      raise
     end
 
     def handle_result


### PR DESCRIPTION
@eapache for review

## Problem

Exceptions that were occurring in `.then` blocks were being re-raised, rather than just causing the returned promise to be rejected.  If `.then` is called on a promise multiple times and an exception occurs in one of the callbacks, then that would prevent additional callbacks from being called.

This behaviour does not appear to be part of the promise spec, and a test with node shows this behaviour isn't consistent with javascript:

```javascript
var resolve = null;
var promise = new Promise(function(resolveFn, rejectFn) {
    resolve = resolveFn;
});
promise.then(function(value) { console.log("first then"); })
promise.then(function(value) { throw "then error" })
promise.then(function(value) { console.log("last then"); })

try {
    resolve("value")
} catch(err) {
    console.log("caught:", err)
}
```

outputs

```
first then
last then
```

## Solution

Remove the `raise` in the exception handler, fix the existing tests that asserted this behaviour, and add a new test to make sure the exception doesn't prevent additional callbacks from being called.