### PR TITLE
feat: Allow Promise#fulfill to be called with a promise.

### DIFF
--- a/config/flog.yml
+++ b/config/flog.yml
@@ -1,2 +1,2 @@
 ---
-threshold: 10.8
+threshold: 9.7

--- a/config/reek.yml
+++ b/config/reek.yml
@@ -60,7 +60,7 @@ TooManyInstanceVariables:
 TooManyMethods:
   enabled: true
   exclude: []
-  max_methods: 12
+  max_methods: 13
 TooManyStatements:
   enabled: true
   exclude:

--- a/spec/unit/promise_spec.rb
+++ b/spec/unit/promise_spec.rb
@@ -390,6 +390,10 @@ describe Promise do
         expect(subject.fulfill(nil)).to eq(nil)
       end
 
+      it 'does not return anything when given a promise' do
+        expect(subject.fulfill(Promise.new)).to eq(nil)
+      end
+
       it 'does not require a value' do
         subject.fulfill
         expect(subject.value).to be(nil)
@@ -399,6 +403,17 @@ describe Promise do
         subject.fulfill
         expect(subject.backtrace.join)
           .to include(__FILE__ + ':' + (__LINE__ - 2).to_s)
+      end
+
+      it 'assumes the state of a given promise' do
+        promise = Promise.new
+
+        subject.fulfill(promise)
+        expect(subject).to be_pending
+        promise.fulfill(123)
+
+        expect(subject).to be_fulfilled
+        expect(subject.value).to eq(123)
       end
     end
 


### PR DESCRIPTION
@eapache for review

## Problem

I noticed that Promise#fulfill didn't support assuming the state of a promise, which isn't really consistent with javascript, where the constructor (i.e. `new Promise(function(resolve, reject) { ... });`) is given a resolve/fulfill function that can take a promise to assume its state.

E.g. in javascript

```javascript
var p1 = new Promise(function(resolveFn, rejectFn) { resolveFn(123) });
var p2 = new Promise(function(resolveFn, rejectFn) { resolveFn(p1) });
p2.then(function(value) { console.log(value) });
```

outputs

```
123
```

but doing something similar in promise.rb

```ruby
p1 = Promise.new
p1.fulfill(123)
p2 = Promise.new
p2.fulfill(p1)
p2.then { |value| puts value }
```

outputs

```
#<Promise:0x007f9336e28198>
```

## Solution

There was already support for this when a promise is returned from an on_fulfill callback, so I just did some refactoring to share that code.  This refactoring also reduces the code complexity that [flog](https://rubygems.org/gems/flog) calculates.