### PR TITLE
fix: Wait for an instance of a subclass of Promise in Promise.all

### DIFF
--- a/lib/promise/group.rb
+++ b/lib/promise/group.rb
@@ -32,7 +32,7 @@ class Promise
     end
 
     def promise?(obj)
-      obj.instance_of?(Promise)
+      obj.is_a?(Promise)
     end
 
     def count_promises

--- a/spec/unit/promise_spec.rb
+++ b/spec/unit/promise_spec.rb
@@ -511,6 +511,16 @@ describe Promise do
         p1.fulfill(1.0)
         expect(result.sync).to eq([1.0, 2])
       end
+
+      it 'returns an instance of the class it is called on' do
+        p1 = DelayedPromise.new
+
+        result = DelayedPromise.all([p1, 2])
+
+        expect(result).to be_pending
+        p1.fulfill(1.0)
+        expect(result.sync).to eq([1.0, 2])
+      end
     end
   end
 end


### PR DESCRIPTION
@eapache for review

## Problem

I used `obj.instance_of?(Promise)` in Promise.all to check for promises in the input, but that only returns true if the class of the object is equal to Promise, rather than supporting a subclass of Promise as I intended.

I actually normally just use `.is_a?` but mutation coverage testing didn't like that, and I thought the only difference between the two was that `.instance_of?` doesn't work with modules.  But really it wanted me to test with subclasses.

## Solution

Change `.instance_of?` to `.is_a?` and add a regression test.