### PR TITLE
feat: Add a Promise#rescue convenience for specifying on_reject.

### DIFF
--- a/config/reek.yml
+++ b/config/reek.yml
@@ -58,9 +58,7 @@ TooManyInstanceVariables:
   exclude: []
   max_instance_variables: 6
 TooManyMethods:
-  enabled: true
-  exclude: []
-  max_methods: 13
+  enabled: false
 TooManyStatements:
   enabled: true
   exclude:

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -96,3 +96,6 @@ LineEndConcatenation:
 
 GuardClause:
   Enabled: false
+
+Alias:
+  EnforcedStyle: prefer_alias_method

--- a/lib/promise.rb
+++ b/lib/promise.rb
@@ -47,6 +47,11 @@ class Promise
     next_promise
   end
 
+  def rescue(&block)
+    self.then(nil, block)
+  end
+  alias_method :catch, :rescue
+
   def sync
     wait if pending?
     raise reason if rejected?

--- a/lib/promise/version.rb
+++ b/lib/promise/version.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
 
 class Promise
-  VERSION = '0.7.0.rc2'
+  VERSION = '0.7.0.rc2'.freeze
 end

--- a/spec/unit/promise_spec.rb
+++ b/spec/unit/promise_spec.rb
@@ -347,6 +347,28 @@ describe Promise do
   end
 
   describe 'extras' do
+    describe '#rescue' do
+      it 'provides an on_reject callback' do
+        result = nil
+        subject.rescue { |reas| result = reas }
+
+        subject.reject(reason)
+        expect(result).to eq(reason)
+        expect(subject.reason).to eq(reason)
+      end
+    end
+
+    describe '#catch' do
+      it 'provides an on_reject callback' do
+        result = nil
+        subject.catch { |reas| result = reas }
+
+        subject.reject(reason)
+        expect(result).to eq(reason)
+        expect(subject.reason).to eq(reason)
+      end
+    end
+
     describe '#progress' do
       let(:status) { double('status') }
 


### PR DESCRIPTION
@eapache for review

Javascript has a convenience function [Promise.prototype.catch](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch) which is the same as `Promise.prototype.then(undefined, onRejected)` and would also be useful in ruby.

I defined a Promise#rescue method, since ruby uses a `rescue` keyword rather than a `catch` keyword for catching exceptions.  However, I have also included an Promise#catch alias for consistency with the ECMAScript standard interface.