### PR TITLE
feat: Add Promise.map_value for chaining a promise or plain value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # promise.rb changelog
 
+## 0.7.1 (June 15, 2016)
+
+### Features
+
+* Add Promise.map_value for chaining a promise or plain value
+
 ## 0.7.0 (February 24, 2016)
 
 ### Features

--- a/lib/promise.rb
+++ b/lib/promise.rb
@@ -22,6 +22,14 @@ class Promise
     Group.new(new, enumerable).promise
   end
 
+  def self.map_value(obj)
+    if obj.is_a?(Promise)
+      obj.then { |value| yield value }
+    else
+      yield obj
+    end
+  end
+
   def initialize
     @state = :pending
     @callbacks = []

--- a/lib/promise/version.rb
+++ b/lib/promise/version.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
 
 class Promise
-  VERSION = '0.7.0'.freeze
+  VERSION = '0.7.1'.freeze
 end

--- a/spec/unit/promise_spec.rb
+++ b/spec/unit/promise_spec.rb
@@ -576,5 +576,23 @@ describe Promise do
         expect(result.sync).to eq([1.0, 2])
       end
     end
+
+    describe '.map_value' do
+      it "yields the argument directly if it isn't a promise" do
+        p = Promise.map_value(2) { |v| v + 1 }
+        expect(p).to eq(3)
+      end
+
+      it 'uses .then on a promise argument using the given block' do
+        p = Promise.map_value(Promise.resolve(2)) { |v| v + 1 }
+        expect(p.sync).to eq(3)
+      end
+
+      it 'uses .then on a promise argument of another class' do
+        p1 = Class.new(Promise).resolve(2)
+        p2 = DelayedPromise.map_value(p1) { |v| v + 1 }
+        expect(p2.sync).to eq(3)
+      end
+    end
   end
 end


### PR DESCRIPTION
@eapache

This avoids the overhead of promise creation when working with plain values
while still being able to support promises without code duplication.