### PR TITLE
Allow to call Promise.resolve without argument

### DIFF
--- a/lib/promise.rb
+++ b/lib/promise.rb
@@ -15,7 +15,7 @@ class Promise
   attr_accessor :source
   attr_reader :state, :value, :reason
 
-  def self.resolve(obj)
+  def self.resolve(obj = nil)
     return obj if obj.is_a?(self)
     new.tap { |promise| promise.fulfill(obj) }
   end

--- a/spec/unit/promise_spec.rb
+++ b/spec/unit/promise_spec.rb
@@ -554,6 +554,12 @@ describe Promise do
         expect(new_promise).to be_fulfilled
         expect(new_promise.value).to eq(42)
       end
+
+      it 'can be passed no argument' do
+        promise = Promise.resolve
+        expect(promise.fulfilled?).to eq(true)
+        expect(promise.value).to eq(nil)
+      end
     end
 
     describe '.all' do


### PR DESCRIPTION
This makes api more consistent as `promise.fullfill` can be called without argument as well
