### PR TITLE
feat: Add Promise.sync to unwrap an object that may be a promise.

### DIFF
--- a/lib/promise.rb
+++ b/lib/promise.rb
@@ -32,6 +32,10 @@ class Promise
     end
   end
 
+  def self.sync(obj)
+    obj.is_a?(Promise) ? obj.sync : obj
+  end
+
   def initialize
     @state = :pending
     @callbacks = []

--- a/spec/unit/promise_spec.rb
+++ b/spec/unit/promise_spec.rb
@@ -514,6 +514,22 @@ describe Promise do
       end
     end
 
+    describe '.sync' do
+      it 'returns non-promise argument' do
+        expect(Promise.sync(42)).to eq(42)
+      end
+
+      it 'calls sync on promise argument' do
+        PromiseLoader.lazy_load(subject) { subject.fulfill(123) }
+        expect(Promise.sync(subject)).to eq(123)
+      end
+
+      it 'calls sync on promise of another class' do
+        promise = Class.new(Promise).resolve('a')
+        expect(Class.new(Promise).sync(promise)).to eq('a')
+      end
+    end
+
     describe '.resolve' do
       it 'returns a fulfilled promise from a non-promise' do
         promise = Promise.resolve(123)


### PR DESCRIPTION
@xuorig please review

## Problem

graphql-batch was calling `GraphQL::Batch::Promise.resolve(raw_value).sync` to unwrap an object that may or may not be a promise.  This pattern is used to call sync on a promise but not on a non-promise object.

## Solution

Add a Promise.sync convenience method that will simplify that pattern to `Promise.sync(raw_value)` which is shorter and doesn't require wrapping the object in the promise if it isn't already a promise.