### PR TITLE
feat: Add `Promise#tap`.

### DIFF
--- a/lib/promise.rb
+++ b/lib/promise.rb
@@ -17,7 +17,7 @@ class Promise
 
   def self.resolve(obj = nil)
     return obj if obj.is_a?(self)
-    new.tap { |promise| promise.fulfill(obj) }
+    new.fulfill(obj)
   end
 
   def self.all(enumerable)
@@ -65,6 +65,15 @@ class Promise
     self.then(nil, block)
   end
   alias_method :catch, :rescue
+
+  def tap
+    return self.then unless block_given?
+
+    self.then do |value|
+      maybe_promise = yield value
+      maybe_promise.is_a?(Promise) ? maybe_promise.then { value } : value
+    end
+  end
 
   def sync
     if pending?

--- a/spec/unit/promise_spec.rb
+++ b/spec/unit/promise_spec.rb
@@ -347,6 +347,66 @@ describe Promise do
   end
 
   describe 'extras' do
+    describe '#tap' do
+      it 'returns a new promise' do
+        p = Promise.resolve(:foobar)
+        p2 = p.tap { nil }
+
+        expect(p2).to be_a(Promise)
+        expect(p2).not_to equal(p)
+      end
+
+      it 'resolves the new promise to the same value' do
+        p = Promise.resolve(:foobar).tap { :foobaz }
+
+        expect(p).to be_fulfilled
+        expect(p.value).to eq(:foobar)
+      end
+
+      it 'waits for a returned promise to be resolved' do
+        p = Promise.new
+        p2 = Promise.resolve(:foobar).tap { p }
+
+        expect(p2).to be_pending
+
+        p.fulfill(:foobaz)
+
+        expect(p2).to be_fulfilled
+        expect(p2.value).to eq(:foobar)
+      end
+
+      it 'rejects if block raises an error' do
+        error = RuntimeError.new('fail')
+        p = Promise.resolve(:foobar).tap { raise error }
+
+        expect(p).to be_rejected
+        expect(p.reason).to eq(error)
+      end
+
+      it 'rejects if returned promise is rejected' do
+        p = Promise.new
+        p2 = Promise.resolve(:foobar).tap { p }
+
+        expect(p2).to be_pending
+
+        error = RuntimeError.new('fail')
+        p.reject(error)
+
+        expect(p2).to be_rejected
+        expect(p2.reason).to eq(error)
+      end
+
+      it 'can be called without a block' do
+        p = Promise.resolve(:foobar)
+        p2 = p.tap
+
+        expect(p2).to be_a(Promise)
+        expect(p2).not_to equal(p)
+        expect(p2).to be_fulfilled
+        expect(p2.value).to eq(:foobar)
+      end
+    end
+
     describe '#rescue' do
       it 'provides an on_reject callback' do
         result = nil
@@ -484,9 +544,9 @@ describe Promise do
       it 'waits for source that is fulfilled with a promise' do
         PromiseLoader.lazy_load(subject) { subject.fulfill(1) }
         p2 = subject.then do |v|
-          Promise.new.tap do |p3|
-            PromiseLoader.lazy_load(p3) { p3.fulfill(v + 1) }
-          end
+          p3 = Promise.new
+          PromiseLoader.lazy_load(p3) { p3.fulfill(v + 1) }
+          p3
         end
         expect(p2).to be_pending
         expect(p2.sync).to eq(2)


### PR DESCRIPTION
This adds a Promise-aware version of `Object#tap`. It essentially works like `Promise#then`, but keeps the original fulfillment value.

Example:

```ruby
p = Promise.resolve(:foobar)
p.tap { |value| other_method_returning_a_promise if value == :foobar }.then do |value|
  value # => :foobar
end
```

---

I'm not too bound to calling this `#tap`. The behaviour is different from `Object#tap`, which might confuse users. On the other hand, it does not feel "wrong" when used. 🤔 