### PR TITLE
Add `Promise#spawn`.

### DIFF
--- a/lib/promise.rb
+++ b/lib/promise.rb
@@ -55,7 +55,7 @@ class Promise
 
   def then(on_fulfill = nil, on_reject = nil, &block)
     on_fulfill ||= block
-    next_promise = self.class.new
+    next_promise = spawn
 
     case state
     when :fulfilled
@@ -155,6 +155,20 @@ class Promise
   end
 
   protected
+
+  # Spawn a new Promise.
+  #
+  # This method is called by `#then` to create a new Promise.
+  #
+  # The default implementation returns a new instance of the same
+  # class as the promise on which `#then` was called. This can be overridden
+  # by subclasses to return promise instances of a different class to be used
+  # for chaining.
+  #
+  # @return [Promise]
+  def spawn
+    self.class.new
+  end
 
   # Override to defer calling the callback for Promises/A+ spec compliance
   def defer


### PR DESCRIPTION
This is a new internal method that is used by `Promise#then` to create a new Promise. This method can be overriden by `Promise` subclasses to have finer grained control about the promise type returned by chaining.

The main target for this method are libraries like `graphql-batch`, which come with their own `Promise` sub-class with a custom `defer` method. In the case of `graphql-batch`, `defer` is overriden to set the current executor's `loading` attribute to false (via `executor.defer`). Unfortunately, this means that `executor.defer` is called for each chained promise as well.

In the following snippet, there's a total of 4 calls to `executor.defer`:

```ruby
require "graphql/batch"

executor = GraphQL::Batch::Executor.new

GraphQL::Batch::Executor.current = executor

p1 = GraphQL::Batch::Promise.new
puts p1.class #=> GraphQL::Batch::Promise

p2 = p1.then do
  executor.loading #=> "false"
end
puts p2.class #=> GraphQL::Batch::Promise

p3 = p2.then do
  executor.loading #=> "false"
end
puts p2.class #=> GraphQL::Batch::Promise

p4 = p3.then do
  executor.loading #=> "false"
end
puts p2.class #=> GraphQL::Batch::Promise

p5 = p4.then do
  executor.loading #=> "false"
end
puts p5.class #=> GraphQL::Batch::Promise

executor.send(:with_loading, true) do
  p1.fulfill(:foo)
end
```

By implementing a custom `GraphQL::Batch::Promise#spawn` that returns `Promise` instances instead of `GraphQL::Batch::Promise` instances, we can get the calls to `executor.defer` down to 1, just for the first promise in the chain:

```ruby
require "graphql/batch"

class GraphQL::Batch::Promise
  protected

  def spawn
    ::Promise.new
  end
end

executor = GraphQL::Batch::Executor.new

GraphQL::Batch::Executor.current = executor

p1 = GraphQL::Batch::Promise.new
puts p1.class #=> GraphQL::Batch::Promise

p2 = p1.then do
  executor.loading #=> "false"
end
puts p2.class #=> Promise

p3 = p2.then do
  executor.loading #=> "false"
end
puts p2.class #=> Promise

p4 = p3.then do
  executor.loading #=> "false"
end
puts p2.class #=> Promise

p5 = p4.then do
  executor.loading #=> "false"
end
puts p5.class #=> Promise

executor.send(:with_loading, true) do
  p1.fulfill(:foo)
end
```