### PR TITLE
[PoC] Promise based coroutines

### DIFF
--- a/lib/promise.rb
+++ b/lib/promise.rb
@@ -1,10 +1,13 @@
 # encoding: utf-8
 
+require 'fiber'
+
 require 'promise/version'
 
 require 'promise/observer'
 require 'promise/progress'
 require 'promise/group'
+require 'promise/coroutine'
 
 class Promise
   Error = Class.new(RuntimeError)
@@ -35,6 +38,12 @@ class Promise
 
   def self.sync(obj)
     obj.is_a?(Promise) ? obj.sync : obj
+  end
+
+  def self.coroutine(&block)
+    coroutine = Promise::Coroutine.new(new, Fiber.new(&block))
+    coroutine.promise_fulfilled(nil, nil)
+    coroutine.promise
   end
 
   def initialize

--- a/lib/promise/coroutine.rb
+++ b/lib/promise/coroutine.rb
@@ -1,0 +1,40 @@
+class Promise::Coroutine
+  include Promise::Observer
+
+  def initialize(promise, fiber)
+    @promise = promise
+    @fiber = fiber
+  end
+
+  attr_reader :promise
+
+  def promise_fulfilled(value, _on_fulfill_arg)
+    result = @fiber.resume(:return, value)
+  rescue => e
+    @promise.reject(e)
+  else
+    continue(result)
+  end
+
+  def promise_rejected(reason, _on_reject_arg)
+    result = @fiber.resume(:raise, reason)
+  rescue => e
+    @fiber = nil
+    @promise.reject(e)
+  else
+    continue(result)
+  end
+
+  def continue(result)
+    return @promise.fulfill(result) unless @fiber.alive?
+
+    case result.state
+    when :fulfilled
+      promise.defer { promise_fulfilled(result.value, nil) }
+    when :rejected
+      promise.defer { promise_rejected(result.reason, nil) }
+    else
+      result.subscribe(self, nil, nil)
+    end
+  end
+end


### PR DESCRIPTION
This adds Promise based coroutines, inspired by Bluebird's `Promise.coroutine` and JavaScript's async/await, but based on Ruby's `Fiber`s.

Example:

```ruby
p1 = Promise.new
p2 = Promise.coroutine do
  Promise.await(p1) + 1
end

p1.pending? # => true
p2.pending? # => true

p1.fulfill(10)
p2.fulfilled? #=> true
p2.value #=> 11
```

`begin...rescue...end` also works:

```ruby
p1 = Promise.new
p2 = Promise.coroutine do
  begin
    Promise.await(p1)
  rescue => e
    e.message
  end
end

p1.pending? # => true
p2.pending? # => true

p1.reject(RuntimeError.new("fail"))
p2.fulfilled? #=> true
p2.value #=> "fail"
```

What do you think? If this is something that would be nice to have in `promise.rb`, I'll add tests and API documentation. 😄

/cc @rmosolgo @josh