### PR TITLE
`Promise.map` and `Promise.filter`

### DIFF
--- a/lib/promise.rb
+++ b/lib/promise.rb
@@ -6,6 +6,7 @@ require 'promise/observer'
 require 'promise/progress'
 require 'promise/group'
 require 'promise/mapping_group'
+require 'promise/filter_group'
 
 class Promise
   Error = Class.new(RuntimeError)
@@ -28,6 +29,10 @@ class Promise
 
   def self.map(enumerable, &block)
     MappingGroup.new(new, enumerable, &block).perform
+  end
+
+  def self.filter(enumerable, &block)
+    FilterGroup.new(new, enumerable, &block).perform
   end
 
   def self.map_value(obj)

--- a/lib/promise.rb
+++ b/lib/promise.rb
@@ -5,6 +5,7 @@ require 'promise/version'
 require 'promise/observer'
 require 'promise/progress'
 require 'promise/group'
+require 'promise/mapping_group'
 
 class Promise
   Error = Class.new(RuntimeError)
@@ -23,6 +24,10 @@ class Promise
 
   def self.all(enumerable)
     Group.new(new, enumerable).promise
+  end
+
+  def self.map(enumerable, &block)
+    MappingGroup.new(new, enumerable, &block).promise
   end
 
   def self.map_value(obj)

--- a/lib/promise.rb
+++ b/lib/promise.rb
@@ -23,11 +23,11 @@ class Promise
   end
 
   def self.all(enumerable)
-    Group.new(new, enumerable).promise
+    Group.new(new, enumerable).perform
   end
 
   def self.map(enumerable, &block)
-    MappingGroup.new(new, enumerable, &block).promise
+    MappingGroup.new(new, enumerable, &block).perform
   end
 
   def self.map_value(obj)

--- a/lib/promise/filter_group.rb
+++ b/lib/promise/filter_group.rb
@@ -1,0 +1,29 @@
+class Promise
+  class FilterGroup < MappingGroup
+    def initialize(result_promise, input, &block)
+      super
+
+      @preserved_values = @values.dup
+    end
+
+    protected
+
+    def promise_fulfilled(value, index)
+      @preserved_values[index] = value unless index.negative?
+
+      super
+    end
+
+    def fulfill
+      result = []
+
+      @preserved_values.each_with_index do |value, index|
+        result.push(value) if @values[index]
+      end
+
+      @promise.fulfill(result)
+    end
+  end
+
+  private_constant :MappingGroup
+end

--- a/lib/promise/group.rb
+++ b/lib/promise/group.rb
@@ -3,7 +3,6 @@ class Promise
     include Promise::Observer
 
     attr_accessor :source
-    attr_reader :promise
 
     def initialize(promise, input)
       @promise = promise
@@ -13,8 +12,6 @@ class Promise
       @resolved_count = 0
 
       @values = @input.is_a?(Array) ? Array.new(@input.size) : []
-
-      iterate
     end
 
     def wait
@@ -32,20 +29,10 @@ class Promise
     end
 
     def promise_rejected(reason, _index)
-      promise.reject(reason)
+      @promise.reject(reason)
     end
 
-    private
-
-    def fulfill
-      @promise.fulfill(@values)
-    end
-
-    def resolved?
-      @total_count && @total_count == @resolved_count
-    end
-
-    def iterate
+    def perform
       index = 0
 
       @input.each do |maybe_promise|
@@ -68,6 +55,18 @@ class Promise
       @total_count = index
 
       fulfill if resolved?
+
+      @promise
+    end
+
+    private
+
+    def fulfill
+      @promise.fulfill(@values)
+    end
+
+    def resolved?
+      @total_count && @total_count == @resolved_count
     end
   end
 

--- a/lib/promise/mapping_group.rb
+++ b/lib/promise/mapping_group.rb
@@ -1,9 +1,9 @@
 class Promise
   class MappingGroup < Group
-    def initialize(result_promise, inputs, &block)
-      @block = block
+    def initialize(result_promise, input, &block)
+      super(result_promise, input)
 
-      super(result_promise, inputs)
+      @block = block
     end
 
     def promise_fulfilled(value, index)

--- a/lib/promise/mapping_group.rb
+++ b/lib/promise/mapping_group.rb
@@ -1,0 +1,36 @@
+class Promise
+  class MappingGroup < Group
+    def initialize(result_promise, inputs, &block)
+      @block = block
+
+      super(result_promise, inputs)
+    end
+
+    def promise_fulfilled(value, index)
+      if index.negative?
+        super(value, ~index)
+      else
+        maybe_promise = begin
+          @block.call(value)
+        rescue => error
+          return promise_rejected(error, index)
+        end
+
+        if maybe_promise.is_a?(Promise)
+          case maybe_promise.state
+          when :fulfilled
+            super(maybe_promise.value, index)
+          when :rejected
+            return promise_rejected(maybe_promise.reason, index)
+          else
+            maybe_promise.subscribe(self, ~index, ~index)
+          end
+        else
+          super(maybe_promise, index)
+        end
+      end
+    end
+  end
+
+  private_constant :MappingGroup
+end


### PR DESCRIPTION
This adds 2 new methods, `Promise.map` and `Promise.filter`, heavily inspired by the equally named methods from the great `bluebird.js` Promise library for JavaScript.

### `Promise.map`

`Promise.map` is similar to `Promise.all`, except that the  values resolved from the input enumerable will be mapped using the provided block. This block can either return `Promise` or non-`Promise` objects. The promise returned by `Promise.map` will be resolved once all values have been mapped.

#### Example

```ruby
values = [1, 2, Promise.resolve(3), 4, 5, Promise.resolve(6)]

async_mapped_values = Promise.map(values) { |value|
  Promise.resolve(value + 1)
}

async_mapped_values.then do |result|
  p result # => [2, 3, 4, 5, 6, 7]
end
```

Without `Promise.map`, the same thing can be achieved like this:

```ruby
values = [1, 2, Promise.resolve(3), 4, 5, Promise.resolve(6)]

Promise.all(values).then do |resolved_values|
  async_mapped_values = Promise.all(resolved_values.map { |value| Promise.resolve(value + 1) })

  async_mapped_values.then do |result|
    p result # => [2, 3, 4, 5, 6, 7]
  end
end
```

#### Advantages

Besides the improved ease-of-use, the native `Promise.map` has better performance over the solution build on `Promise.all`. `Promise.map` can interleave the process of resolving values and mapping them to their final value, while these are two separate steps in the alternative version using `Promise.all`.

### `Promise.filter`

`Promise.filter` allows filtering an enumerable containing `Promise` and/or non-`Promise` values, based on the given filter block. The filter block can return either `Promise` or non-`Promise` values.

#### Example

```ruby
values = [1, 2, Promise.resolve(3), 4, 5, Promise.resolve(6)]

async_filtered_values = Promise.filter(values) { |value|
  Promise.resolve(value.even?)
}

async_filtered_values.then do |result|
  p result # => [2, 4, 6]
end
```

Without `Promise.filter`, the same thing can be achieved like this:

```ruby
values = [1, 2, Promise.resolve(3), 4, 5, Promise.resolve(6)]

Promise.all(values).then do |resolved_values|
  async_filter_results = Promise.all(resolved_values.map { |value| Promise.resolve(value.even?) })

  async_filter_results.then do |filter_results|
    result = resolved_values.filter.with_index { |value, index| filter_results[index] }
    p result # => [2, 3, 4, 5, 6, 7]
  end
end
```

#### Advantages

Again, the version built on `Promise.filter` is a lot easier to understand. Similar to `Promise.map`, `Promise.filter` can perform the initial value resolution and filtering process at the same time, where as the version built on `Promise.all` performs two discrete steps.