### PR TITLE
Pin `devtools` gem to a specific version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ if Gem.ruby_version < Gem::Version.new('2.0')
   gem 'tins', '~> 1.6.0'
 end
 if Gem.ruby_version >= Gem::Version.new('2.1')
-  gem 'devtools', '~> 0.1.16'
+  gem 'devtools', '0.1.18'
 end
 
 gem 'awesome_print'


### PR DESCRIPTION
Apparently, newer versions of the `devtools` gem changed the default configuration in ways that make the code that previously passed with version `0.1.18` of `devtools` fail.

Let's pin to `0.1.18`, so we don't have to look into updating all the existing code just to make some style checker happy.

/cc @dylanahsmith @xuorig