### PR TITLE
Fix ruby 2.6 mutation tests from the introduction of Object#then

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ jobs:
       matrix:
         ruby:
           - '2.1.9' # earliest supported by ruby/setup-ruby
-          - '2.5.8' # latest passing mutation tests, will fix in a follow-up PR
+          - '2.6.0' # test Promise.map_value ruby version condition
+          - '2.7.2' # latest passing on CI, will update to 3.0.0 in a follow-up PR
           - 'jruby'
 
     steps:

--- a/lib/promise.rb
+++ b/lib/promise.rb
@@ -25,11 +25,18 @@ class Promise
     Group.new(new, enumerable).promise
   end
 
-  def self.map_value(obj)
-    if obj.is_a?(Promise)
+  if Gem.ruby_version >= Gem::Version.new('2.6.0')
+    # @deprecated Use {Object#then} instead
+    def self.map_value(obj)
       obj.then { |value| yield value }
-    else
-      yield obj
+    end
+  else
+    def self.map_value(obj)
+      if obj.is_a?(Promise)
+        obj.then { |value| yield value }
+      else
+        yield obj
+      end
     end
   end
 


### PR DESCRIPTION
@kachick

## Problem

Mutation testing noticed that the tests pass with the following change

```
evil:Promise.map_value:/Users/dylants/src/promise.rb/lib/promise.rb:28:4e8f7
@@ -1,10 +1,10 @@
 def self.map_value(obj)
-  if obj.is_a?(Promise)
+  if true
     obj.then do |value|
       yield(value)
     end
   else
     yield(obj)
   end
 end
```

which was happening because Object#then was added to ruby 2.6 which allowed the `then` method to work on all objects.

## Solution

I defined a simpler version of the method for ruby 2.6+ and deprecated this method, since the introduction of Object#then makes it do exactly what we want, to be able to call `then` on any object when we aren't sure if we are dealing with a promise or not and don't need to convert the value to a promise.