### PR TITLE
Remove rubinius platform-specific gems from Gemfile to fix ruby 3 compat

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,3 @@ gem 'fuubar', '~> 2.0.0'
 gem 'rake'
 gem 'rspec', '~> 3.5'
 gem 'rspec-its'
-
-platform :rbx do
-  gem 'rubinius', '~> 2.0'
-  gem 'rubysl', '~> 2.0'
-end

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,6 @@ if Gem.ruby_version >= Gem::Version.new('2.2')
     metrics:reek
     spec:integration
   ]
-  tasks << 'metrics:coverage' unless RUBY_ENGINE == 'rbx'
   tasks << 'metrics:mutant' if RUBY_ENGINE == 'ruby'
   task :default => tasks
 else


### PR DESCRIPTION
@kachick

## Problem

For some reason `bundle install` failed without an existing Gemfile on ruby 3.0.0

<details><summary>error output</summary>

```
Bundler found conflicting requirements for the Ruby version:
  In Gemfile:
    Ruby x86_64-darwin-19

    rubysl (~> 2.0) x86_64-darwin-19 was resolved to 2.2.0, which depends on
      rubysl-fcntl (~> 2.0) was resolved to 2.0.4, which depends on
        Ruby (~> 2.0)

Bundler could not find compatible versions for gem "mutant":
  In Gemfile:
    devtools (= 0.1.18) x86_64-darwin-19 was resolved to 0.1.18, which depends on
      mutant (~> 0.8.11) x86_64-darwin-19

    devtools (= 0.1.18) x86_64-darwin-19 was resolved to 0.1.18, which depends on
      mutant-rspec (~> 0.8.11) x86_64-darwin-19 was resolved to 0.8.16, which depends on
        mutant (~> 0.8.16) x86_64-darwin-19

Bundler could not find compatible versions for gem "parser":
  In Gemfile:
    devtools (= 0.1.18) x86_64-darwin-19 was resolved to 0.1.18, which depends on
      mutant (~> 0.8.11) x86_64-darwin-19 was resolved to 0.8.16, which depends on
        parser (>= 2.3.1.4, < 2.5) x86_64-darwin-19

    devtools (= 0.1.18) x86_64-darwin-19 was resolved to 0.1.18, which depends on
      reek (~> 4.6.0) x86_64-darwin-19 was resolved to 4.6.2, which depends on
        parser (< 2.5, >= 2.4.0.0) x86_64-darwin-19

    devtools (= 0.1.18) x86_64-darwin-19 was resolved to 0.1.18, which depends on
      rubocop (~> 0.47.0) x86_64-darwin-19 was resolved to 0.47.1, which depends on
        parser (>= 2.3.3.1, < 3.0) x86_64-darwin-19

    devtools (= 0.1.18) x86_64-darwin-19 was resolved to 0.1.18, which depends on
      mutant (~> 0.8.11) x86_64-darwin-19 was resolved to 0.8.16, which depends on
        unparser (~> 0.2.5) x86_64-darwin-19 was resolved to 0.2.8, which depends on
          parser (>= 2.3.1.2, < 2.6) x86_64-darwin-19

Bundler could not find compatible versions for gem "rake":
  In Gemfile:
    rake x86_64-darwin-19

    devtools (= 0.1.18) x86_64-darwin-19 was resolved to 0.1.18, which depends on
      rake (~> 12.0.0) x86_64-darwin-19

Bundler could not find compatible versions for gem "rspec":
  In Gemfile:
    rspec (~> 3.5) x86_64-darwin-19

    fuubar (~> 2.0.0) x86_64-darwin-19 was resolved to 2.0.0, which depends on
      rspec (~> 3.0) x86_64-darwin-19

Bundler could not find compatible versions for gem "rspec-core":
  In Gemfile:
    devtools (= 0.1.18) x86_64-darwin-19 was resolved to 0.1.18, which depends on
      rspec-core (~> 3.5.4) x86_64-darwin-19

    devtools (= 0.1.18) x86_64-darwin-19 was resolved to 0.1.18, which depends on
      mutant-rspec (~> 0.8.11) x86_64-darwin-19 was resolved to 0.8.16, which depends on
        rspec-core (>= 3.4.0, < 4.0.0) x86_64-darwin-19

    rspec (~> 3.5) x86_64-darwin-19 was resolved to 3.5.0, which depends on
      rspec-core (~> 3.5.0) x86_64-darwin-19

    devtools (= 0.1.18) x86_64-darwin-19 was resolved to 0.1.18, which depends on
      rspec-its (~> 1.2.0) x86_64-darwin-19 was resolved to 1.2.0, which depends on
        rspec-core (>= 3.0.0) x86_64-darwin-19

Bundler could not find compatible versions for gem "rspec-expectations":
  In Gemfile:
    rspec (~> 3.5) x86_64-darwin-19 was resolved to 3.5.0, which depends on
      rspec-expectations (~> 3.5.0) x86_64-darwin-19

    devtools (= 0.1.18) x86_64-darwin-19 was resolved to 0.1.18, which depends on
      rspec-its (~> 1.2.0) x86_64-darwin-19 was resolved to 1.2.0, which depends on
        rspec-expectations (>= 3.0.0) x86_64-darwin-19

Bundler could not find compatible versions for gem "rspec-its":
  In Gemfile:
    rspec-its x86_64-darwin-19

    devtools (= 0.1.18) x86_64-darwin-19 was resolved to 0.1.18, which depends on
      rspec-its (~> 1.2.0) x86_64-darwin-19
```

</details>

This seems like it might be a bundler bug, since it passes with an existing Gemfile.lock generated using ruby 2.7.2 and it passes when the rubysl gem is used, which is condiitonal to the rubinius platform.

## Solution

CI hasn't been getting tested on rubinius for a while, so we may as well remove any rubinius specific from the Gemfile considering that it is just dead code right now.